### PR TITLE
コラムの途中で改ページできるように変更

### DIFF
--- a/articles/sty/techbooster-doujin.sty
+++ b/articles/sty/techbooster-doujin.sty
@@ -143,7 +143,7 @@
 
 \renewenvironment{reviewcolumn}{%
      \vspace{\baselineskip}
-     \begin{tcolorbox}[colback=white]
+     \begin{tcolorbox}[breakable, colback=white]
    }{%
       \end{tcolorbox}
      \vspace{\baselineskip}


### PR DESCRIPTION
デフォルトのコンフィグに指定されているスタイル `techbooster-doujin.sty` では
コラムが長く1ページに収まりきらないときにはページから溢れてしまうことがありました。
ひょっとするとそのような使い方を想定されていないのかも知れませんが、
`breakable` オプションを付けることで改ページできるようになり、
より使いやすくなると思われますのでプルリクエストをお送りします。