### PR TITLE
CircleCI の Docker Image を Re:VIEWを2.5.0に更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: vvakame/review:2.4
+      - image: vvakame/review:2.5
     steps:
       - checkout
       - restore_cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: vvakame/review:2.4
+image: vvakame/review:2.5
 
 build-pdf:
   script: # build-in-docker.sh の終盤と同じもの


### PR DESCRIPTION
[3b32fb6] に伴いCircleCIで読み込むコンテナも更新する必要があったので。