### PR TITLE
印刷用の修正

### DIFF
--- a/articles/sty/techbooster-doujin.sty
+++ b/articles/sty/techbooster-doujin.sty
@@ -40,6 +40,7 @@
     \markboth{#1}{#1}
   \fi}
 \renewcommand{\headfont}{\gtfamily\sffamily\bfseries}
+\renewcommand{\reviewtitlefont}{\gtfamily\sffamily\bfseries}
 
 \fancypagestyle{plainhead}{%
 \fancyhead{}

--- a/articles/sty/techbooster-doujin.sty
+++ b/articles/sty/techbooster-doujin.sty
@@ -49,7 +49,7 @@
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}}
 
-\hypersetup{colorlinks=false}
+\hypersetup{colorlinks=false,hidelinks}
 %%Helveticaを使う
 \renewcommand{\sfdefault}{phv}
 


### PR DESCRIPTION
修正点は以下の2点です。

## 印刷用ではハイパーリンクが表示されないよう修正

#### before:

![2018-09-18 21 31 54](https://user-images.githubusercontent.com/10401/45687716-6c339180-bb8a-11e8-9f1c-450586e53d51.png)

#### after:

![2018-09-18 21 31 59](https://user-images.githubusercontent.com/10401/45687729-70f84580-bb8a-11e8-8fcc-69cd39873535.png)

## 見出しのフォントの太さを日英で揃える

#### before:

![2018-09-18 21 31 28](https://user-images.githubusercontent.com/10401/45687755-81a8bb80-bb8a-11e8-83f0-01b535551871.png)

#### after:

![2018-09-18 21 31 33](https://user-images.githubusercontent.com/10401/45687765-85d4d900-bb8a-11e8-8dd4-12381069ae7c.png)

----

※このpull requestはmaster向けの修正ですが、Template-A5にも同様の修正を追加していただければ。