### PR TITLE
目次後の空ページの処理

### DIFF
--- a/articles/sty/techbooster-doujin-base.sty
+++ b/articles/sty/techbooster-doujin-base.sty
@@ -177,6 +177,12 @@
   }
 \fi
 
+% jsbookのmainmatterの内部oddpage処理を\clearoddpage利用に
+\renewcommand\mainmatter{%
+  \clearoddpage
+  \@mainmattertrue
+  \pagenumbering{arabic}}
+
 % 奥付を必ず偶数開始
 \renewcommand{\reviewcolophon}[0]{\clearoddpage}
 

--- a/articles/sty/techbooster-doujin-base.sty
+++ b/articles/sty/techbooster-doujin-base.sty
@@ -177,9 +177,15 @@
   }
 \fi
 
-% jsbookのmainmatterの内部oddpage処理を\clearoddpage利用に
+% jsbookのmainmatterの内部oddpage処理を変更
 \renewcommand\mainmatter{%
-  \clearoddpage
+  \if@openleft
+    \cleardoublepage
+  \else\if@openright
+    \cleardoublepage
+  \else
+    \clearpage
+  \fi\fi
   \@mainmattertrue
   \pagenumbering{arabic}}
 


### PR DESCRIPTION
#30 の対応です。

- 白ページにノンブルがつかなかった理由ですが、目次の後に呼ばれる\mainmatterの処理のほうで、jsbook/platex固有の改ページ処理があり、ここで独自の白ページが入っていました。
- そこで、\mainmatterを書き換えます。
- texdocumentclassでopenanyオプションを付けていなかった場合は、目次ページが奇数で終わった場合に白+ノンブルの偶数ページを配置し、1章を必ず奇数から始めるようにします。
- texdocumentclassでopenanyオプションを付けていた場合は、目次ページが奇数で終わった場合にはそのまま1章を偶数ページでも始めるようにします。

この挙動だといかがでしょうか。