### PR TITLE
Add flushright in css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 Gemfile.lock
 *.pdf
+.sass-cache/
 
 articles/*.pdf
 articles/*.epub

--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ Re:VIEW 3で変わったことの詳細については、以下を参照して�
 
 * https://github.com/TechBooster/ReVIEW-Template/releases
 
+### EPUB/Web出力用CSSファイルの編集方法
+
+articles/ディレクトリ以下の各種*.scssファイルを編集し、
+
+```
+./rebuild-css.sh
+```
+
+コマンドでCSSファイルをビルドしてください。
+
 ## 権利
 
  * 設定ファイル、テンプレートなど制作環境（techbooster-doujin-base.styなど）はMITライセンスです

--- a/articles/epub_style.css
+++ b/articles/epub_style.css
@@ -15,9 +15,9 @@ body {
   line-height: 1.6;
   font-family: "ShinGoPro-Regular","ShinGo-Regular", sans-serif;
   /*
-  word-break: normal;
-  -webkit-line-break: after-white-space;
-  */ }
+    word-break: normal;
+    -webkit-line-break: after-white-space;
+    */ }
 
 p, ul, ol, dl, pre, table {
   font-family: "ShinGo Regular","ShinGo R","新ゴR","新ゴ R", sans-serif;

--- a/articles/style.css
+++ b/articles/style.css
@@ -37,6 +37,9 @@ div.lead {
   font-size: 16px;
   margin-left: 3em; }
 
+p.flushright {
+  text-align: right; }
+
 .noteref {
   vertical-align: super;
   font-size: smaller; }

--- a/articles/style.scss
+++ b/articles/style.scss
@@ -50,6 +50,11 @@ div.lead {
 	margin-left: 3em;
 }
 
+// 右寄せ文
+p.flushright {
+	text-align: right;
+}
+
 // footnote
 .noteref {
 	vertical-align: super;

--- a/rebuild-css.sh
+++ b/rebuild-css.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+npm install --no-save node-sass
+$(npm bin)/node-sass ./articles/ --output ./articles/


### PR DESCRIPTION
Depends on: #38

`flushright`ブロック(右寄せ)は`review-webmaker`の出力でclass指定されていますが配布CSSにスタイル定義が無かったので追加しました。

利用例は次の通りです。

```
= 章タイトル

//flushright{
著者だよ
//}

ここからすべてが始まる！
```

![Screenshot from 2019-03-26 12-58-56](https://user-images.githubusercontent.com/766864/54970790-f68c0080-4fc6-11e9-844d-a48df58d51b7.png)
