### PR TITLE
表紙をノンブルなしに

### DIFF
--- a/articles/sty/review-jsbook.cls
+++ b/articles/sty/review-jsbook.cls
@@ -1,5 +1,5 @@
 %#!ptex2pdf -l -u -ot '-synctex=1' test-rejsbk
-% Copyright (c) 2018 Munehiro Yamamoto, Kenshi Muto.
+% Copyright (c) 2018-2019 Munehiro Yamamoto, Kenshi Muto.
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -458,8 +458,8 @@
 
 %% シンプルな通しノンブル
 \ifrecls@serialpage
-\renewcommand*{\pagenumbering}[1]{%
-  \gdef\thepage{\@arabic\c@page}}
+\def\pagenumbering#1{%
+  \gdef\thepage{\csname @arabic\endcsname\c@page}}
 \fi
 
 %% 開始ページを変更

--- a/articles/sty/techbooster-doujin-base.sty
+++ b/articles/sty/techbooster-doujin-base.sty
@@ -141,6 +141,21 @@
 \renewcommand{\reviewtitlefont}{\gtfamily\sffamily\bfseries}
 
 % 既存命令のemptyページスタイルをパッチでplainheadに変更
+% ノンブルなし版を保持
+\let\includefullpagegraphicswithoutnmbl\includefullpagegraphics
+% 表紙画像にはwithoutnmbl版利用
+\if@reclscover
+  \ifdefined\review@coverfile% ファイル明示指定のときには何もしない
+  \else
+    \ifdefined\review@coverimage
+      \def\reviewcoverpagecont{% withoutnmbl版で再定義
+        \expandafter\includefullpagegraphicswithoutnmbl\expandafter[\review@coverimageoption]{\review@coverimage}
+        \cleardoublepage
+      }
+    \fi
+  \fi
+\fi
+
 \patchcmd{\includefullpagegraphics}{%
 {\thispagestyle{empty}\@includefullpagegraphics}
 }{%


### PR DESCRIPTION
#42 の対応。
ノンブルなしでの全面貼り付けマクロを別定義し、coverマクロはそれを使うようにします。
