### PR TITLE
CircleCIのartifacts保存時にファイル名に依存しないようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,11 @@ jobs:
       - run:
           name: Build PDF
           command: npm run pdf
+      - run:
+          name: Preparing artifacts
+          command: |
+            mkdir -p /tmp/artifacts
+            cp ./articles/*.pdf /tmp/artifacts
       - store_artifacts:
-          path: ./articles/ReVIEW-Template.pdf
-          destination: ReVIEW-Template.pdf
+          path: /tmp/artifacts
+          destination: /


### PR DESCRIPTION
ビルドしたPDFを保存する設定がファイル名に依存してしまっていたのを解消します。

