### PR TITLE
Re:VIEWバージョンの更新手順にstyファイルの上書きを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ config.yml: 'review_version' を '4.0' に更新しますか? [y]/n
 完了しました。
 ```
 
+その後、articles/sty/reviewmacro.styとarticles/sty/techbooster-doujin-base.styを本リポジトリのファイルで上書きしてください。
+
 ## 過去のRe:VIEW 2依存プロジェクトをRe:VIEW 4に移行する
 
 Re:VIEW 2系向けの過去のTechBoosterテンプレートは、Re:VIEW 3以降とは互換性がありません。Re:VIEWは2から3以上への移行を支援する「review-update」というコマンドを提供していますが、TechBoosterテンプレートを使用しているプロジェクトは対象外となっています。


### PR DESCRIPTION
review-updateによってtechbooster-doujin-base.styを読み込んでいるreviewmacro.styが更新されるため。
更新を拒否するだけでも良いのですが、Re:VIEW本体やRe:VIEW Templateによって修正が入る可能性を考えると、最新のもので上書きするのが確実だと思います。