### PR TITLE
Fix docker build readme and shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ TeXの環境構築が困難な場合、一式セットアップ済みの[docker�
 Dockerがうまく動くようになっている場合、以下のコマンドで細かい準備なしにビルドを行うことができます。
 
 ```
-$ docker pull vvakame/review:4.1
+$ docker pull vvakame/review:5.0
 $ ./build-in-docker.sh
 ```
 

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -5,3 +5,6 @@
 # docker run -i -t -v $(pwd):/book vvakame/review:5.0 /bin/bash
 
 docker run -t --rm -v $(pwd):/book vvakame/review:5.0 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"
+
+# Linux上でDockerを使うと書き込まれたファイルの所有権がroot:rootになってしまうため
+sudo chown -R `id -u`:`id -g` ./


### PR DESCRIPTION
Docker pullのイメージ名が古いままだったのと、Linux上でbuildするとコンテナ内ユーザーのrootでファイルが書き換わってしまい、ホスト側で困ったのでそれを修正する対応を入れています。

本質的にはDockerイメージで実行ユーザーをnon-rootでやるべきなのですが、ちょっと根が深そうなのでshellの中できる範囲で対応を入れました。

macOSでの動作は確認できていない（手元にmacがない）ため、ご確認いただけると幸いです :pray: