### PR TITLE
Docker Composeの設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM vvakame/review:5.0
+
+ENV APP_HOME /book
+RUN mkdir -p $APP_HOME
+WORKDIR $APP_HOME
+
+ADD Gemfile Gemfile
+ADD package.json package.json
+ADD package-lock.json package-lock.json
+
+RUN gem install bundler:1.17.2
+RUN npm install --unsafe-perm

--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ $ docker pull vvakame/review:4.1
 $ ./build-in-docker.sh
 ```
 
+## Docker Composeを使う
+
+`./build-in-docker.sh`の場合、毎回gem installやnpm installが走るので、
+Docker Composeでそれらを含んだ環境を作れます。
+
+初回はビルドが走りますが、二回目以降は`npm run pdf`だけが走ります。
+
+```sh
+$ ./build-in-docker-compose.sh
+```
+
 ## 紙面や設定ファイルの切り替え
 
 B5やA5といった紙面サイズ、印刷用・電子用といったメディアの切り替えは、articles/config.ymlのtexdocumentclassパラメータで設定しています。

--- a/build-in-docker-compose.sh
+++ b/build-in-docker-compose.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+[ ! -z $REVIEW_CONFIG_FILE ] || REVIEW_CONFIG_FILE=config.yml
+
+# コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
+# docker run -i -t -v $(pwd):/book vvakame/review:5.0 /bin/bash
+
+#docker run -t --rm -v $(pwd):/book vvakame/review:5.0 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"
+docker-compose run --rm review /bin/bash -ci "cd /book && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"

--- a/build-in-docker-compose.sh
+++ b/build-in-docker-compose.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 [ ! -z $REVIEW_CONFIG_FILE ] || REVIEW_CONFIG_FILE=config.yml
 
-# コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
-# docker run -i -t -v $(pwd):/book vvakame/review:5.0 /bin/bash
-
-#docker run -t --rm -v $(pwd):/book vvakame/review:5.0 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"
 docker-compose run --rm review /bin/bash -ci "cd /book && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  review:
+    build: .
+    volumes:
+      - .:/book
+      - bundle:/usr/local/bundle
+      - /book/node_modules
+volumes:
+  bundle:


### PR DESCRIPTION
Docker Composeの設定を追加した。
build-in-docker.shだとsetup.shを毎回叩いて、bundlerのインストールやnode_modulesの入れ直しから走るので、予めそれらを含んだimageを作るようにした