### PR TITLE
mdファイルをGruntでの削除対象にしない

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,6 @@ module.exports = grunt => {
 					`${articles}/*.pdf`,
 					`${articles}/*.epub`,
 					`${articles}/*.html`,
-					`${articles}/*.md`,
 					`${articles}/*.xml`,
 					`${articles}/*.txt`,
 					`${articles}/webroot`


### PR DESCRIPTION
@mhidaka 
#79 の修正です。npm runのclean対象からmdファイルを除きます。

npm run md と相性が悪くなりますが、どっちを優先かを考えるとしょうがないですね…。
