### PR TITLE
Bump up actions to the latest major release

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -4,19 +4,18 @@ on: [push]
 
 jobs:
   build:
-    name: 
     runs-on: ubuntu-latest
     steps:
-    # uses v2 Stable version
+    # uses v3 Stable version
     # https://github.com/actions/checkout
     - name: checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     # Build Artifacts
     - name: Build distribution file
       uses: TechBooster/ReVIEW-build-artifact-action@master
     # Upload Distribution file
     - name: Upload distribution file to github artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Output documents
         path: ./articles/*.pdf


### PR DESCRIPTION
ReVIEWテンプレートの公開ありがとうございます :bow:
Node12がEOLになっているので、Node16を使う新しいActionsに置き換えたほうが良いかと思い変更を提案させてください。
またジョブの `name` が未指定になっていて、大きな問題ではないのですがこれもあわせて削除して良いかなと思っています。

参考までに、現時点のワークフローは以下のような警告を表示します。またprivate repoでの動作確認は済んでいます。

<img width="1066" alt="Screenshot 2023-01-08 at 9 58 47" src="https://user-images.githubusercontent.com/505751/211177319-f862839d-db0f-4b4e-a34d-bfd8cea91c1b.png">
