### PR TITLE
support Re:VIEW 5.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
   vvakame-executor:
     working_directory: ~/review
     docker:
-      - image: vvakame/review:5.7
+      - image: vvakame/review:5.8
 
 # -------------------------
 # COMMANDS

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "vvakame/review:5.7",
+	"image": "vvakame/review:5.8",
 	"settings": {
 		"editor.wordWrap": "on"
 	},

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: vvakame/review:5.7
+image: vvakame/review:5.8
 
 build-pdf:
   script: # build-in-docker.sh の終盤と同じもの

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,3 @@
-image: vvakame/review:5.7
+image: vvakame/review:5.8
 tasks:
 - command: ./setup.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem 'review', '5.7.0'
+gem 'review', '5.8.0'
 gem 'pandoc2review'
+gem 'playwright-runner'
 gem 'rake'
 # gem 'review-peg', '0.2.2'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Re:VIEW Template
 
-このリポジトリはRe:VIEW用の書籍テンプレートです。Re:VIEWバージョン5.7に対応します。
+このリポジトリはRe:VIEW用の書籍テンプレートです。Re:VIEWバージョン5.8に対応します。
 メンテナンスはTechBoosterが行っています。
 
  * [B5紙面サンプル（PDF）](https://github.com/TechBooster/ReVIEW-Template/tree/master/pdf-sample/TechBooster-Template-B5.pdf)
@@ -135,8 +135,8 @@ TeXの環境構築が困難な場合、一式セットアップ済みのDocker�
 Dockerがうまく動くようになっている場合、以下のコマンドで細かい準備なしにビルドを行うことができます。
 
 ```
-$ docker pull ghcr.io/vvakame/review:5.7 (ghcrからのダウンロードの場合)
-$ docker pull vvakame/review:5.7 (Docker Hubからのダウンロードの場合)
+$ docker pull ghcr.io/vvakame/review:5.8 (ghcrからのダウンロードの場合)
+$ docker pull vvakame/review:5.8 (Docker Hubからのダウンロードの場合)
 $ ./build-in-docker.sh
 ```
 
@@ -230,10 +230,10 @@ Re:VIEW 3以降のプロジェクトは、review-updateコマンドで簡単に�
 
 ```
 $ review-update
-** review-update はプロジェクトを 5.7.0 に更新します **
+** review-update はプロジェクトを 5.8.0 に更新します **
 config.yml: 'review_version' を '5.0' に更新しますか? [y]/n
-プロジェクト/sty/review-base.sty は Re:VIEW バージョンのもの (/var/lib/gems/2.7.0/gems/review-5.7.0/templates/latex/review-jsbook/review-base.sty) で置き換えられます。本当に進めますか? [y]/n
-プロジェクト/sty/review-jsbook.cls は Re:VIEW バージョンのもの (/var/lib/gems/2.7.0/gems/review-5.7.0/templates/latex/review-jsbook/review-jsbook.cls) で置き換えられます。本当に進めますか? [y]/n
+プロジェクト/sty/review-base.sty は Re:VIEW バージョンのもの (/var/lib/gems/2.7.0/gems/review-5.8.0/templates/latex/review-jsbook/review-base.sty) で置き換えられます。本当に進めますか? [y]/n
+プロジェクト/sty/review-jsbook.cls は Re:VIEW バージョンのもの (/var/lib/gems/2.7.0/gems/review-5.8.0/templates/latex/review-jsbook/review-jsbook.cls) で置き換えられます。本当に進めますか? [y]/n
 完了しました。
 ```
 
@@ -278,6 +278,7 @@ layouts/layouts.tex.erbやsty/techbooster-doujin.styに何らかのカスタマ�
 
 Re:VIEW 3以降で変わったことの詳細については、以下を参照してください。
 
+* [Re:VIEW 5.8 での変更点](https://review-knowledge-ja.readthedocs.io/ja/latest/releases/review580.html)
 * [Re:VIEW 5.7 での変更点](https://review-knowledge-ja.readthedocs.io/ja/latest/releases/review570.html)
 * [Re:VIEW 5.6 での変更点](https://review-knowledge-ja.readthedocs.io/ja/latest/releases/review560.html)
 * [Re:VIEW 5.5 での変更点](https://review-knowledge-ja.readthedocs.io/ja/latest/releases/review550.html)

--- a/articles/config.yml
+++ b/articles/config.yml
@@ -267,6 +267,19 @@ direction: "ltr"
 # 追加する<meta>要素のプロパティとその値
 # opf_meta: {"ebpaj:guide-version": "1.1.3"}
 
+# Playwrightの利用オプション
+playwright_options:
+  # playwrightコマンドのパス
+  # playwright_path: "./node_modules/.bin/playwright"
+  # DockerのRe:VIEWではplaywrightをプリインストールしているためデフォルトを/usr/binのものに変更
+  playwright_path: "/usr/bin/playwright"
+  # playwright-runnerの切り取りを使う。pdfcropを使う場合はfalseにする
+  # selfcrop: true
+  # pdfcropコマンドのパス
+  # pdfcrop_path: "pdfcrop"
+  # pdftocairoコマンドのパス
+  # pdftocairo_path: "pdftocairo"
+
 # 以下のパラメータを有効にするときには、
 # epubmaker:
 #    パラメータ: 値

--- a/articles/sty/review-jsbook.cls
+++ b/articles/sty/review-jsbook.cls
@@ -400,6 +400,20 @@
 ]{hyperref}
 \RequirePackage{pxjahyper}
 
+%% better line breaks for long urls
+\AtBeginDocument{%
+  %% modified url.sty
+  \def\UrlBreaks{%
+    \do\0\do\1\do\2\do\3\do\4\do\5\do\6\do\7\do\8\do\9%
+    \do\A\do\B\do\C\do\D\do\E\do\F\do\G\do\H\do\I\do\J\do\K\do\L\do\M\do\N%
+    \do\O\do\P\do\Q\do\R\do\S\do\T\do\U\do\V\do\W\do\X\do\Y\do\Z%
+    \do\a\do\b\do\c\do\d\do\e\do\f\do\g\do\h\do\i\do\j\do\k\do\l\do\m\do\n%
+    \do\o\do\p\do\q\do\r\do\s\do\t\do\u\do\v\do\w\do\x\do\y\do\z%
+    %%
+    \do\.\do\@\do\\\do\/\do\!\do\_\do\|\do\;\do\>\do\]%
+    \do\)\do\,\do\?\do\&\do\'\do+\do\=\do\#}%
+}
+
 %% more useful macros
 %% ----------
 %% include fullpage graphics

--- a/articles/sty/techbooster-doujin-base.sty
+++ b/articles/sty/techbooster-doujin-base.sty
@@ -52,7 +52,8 @@
 \renewcommand{\captionsize}{\fontsize{9}{9}\selectfont}
 \newlength{\captionnumwidth}
 \setlength{\captionnumwidth}{6zw}
-%\newlength{\captionwidth}
+
+\newlength{\captionwidth}
 \setlength{\captionwidth}{\textwidth}
 \addtolength{\captionwidth}{-\captionnumwidth}
 \def\captionhead{\sffamily{\color{black!30!white}{▲}}}

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -2,6 +2,6 @@
 [ ! -z $REVIEW_CONFIG_FILE ] || REVIEW_CONFIG_FILE=config.yml
 
 # コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
-# docker run -i -t -v $(pwd):/book vvakame/review:5.7 /bin/bash
+# docker run -i -t -v $(pwd):/book vvakame/review:5.8 /bin/bash
 
-docker run -t --rm -v $(pwd):/book vvakame/review:5.7 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"
+docker run -t --rm -v $(pwd):/book vvakame/review:5.8 /bin/bash -ci "cd /book && ./setup.sh && REVIEW_CONFIG_FILE=$REVIEW_CONFIG_FILE npm run pdf"


### PR DESCRIPTION
Re:VIEW 5.8.0に更新しました。

TeXLiveバージョンが上がったせいか、techbooster-doujin-base.styでcaptionwidthの定義が再度必要になったので設定しています。

Playwright環境入れてconfig.ymlでもすぐ動くようにしてあるので、以下もできます。

```
//graph[id1][mermaid]{
sequenceDiagram
ぽち->>たま: 遊べる？
たま-->>ぽち: いいよ！
//}
```

レビューお願いいたします＞ @vvakame or @mhidaka 