### PR TITLE
fix LaTeX compile error

### DIFF
--- a/articles/sty/techbooster-doujin-base.sty
+++ b/articles/sty/techbooster-doujin-base.sty
@@ -52,7 +52,7 @@
 \renewcommand{\captionsize}{\fontsize{9}{9}\selectfont}
 \newlength{\captionnumwidth}
 \setlength{\captionnumwidth}{6zw}
-%\newlength{\captionwidth}
+\newlength{\captionwidth}
 \setlength{\captionwidth}{\textwidth}
 \addtolength{\captionwidth}{-\captionnumwidth}
 \def\captionhead{\sffamily{\color{black!30!white}{▲}}}


### PR DESCRIPTION
LaTeXのコンパイルに失敗する問題を解決しました。
uplatex -interaction=nonstopmode -file-line-error -halt-on-error _REVIEW_BOOK_.tex の実行でコケていたので、応急処置として articles/sty/techbooster-doujin-base.sty 内の newlength コマンドのコメントアウトを解除しました。
一応コンパイルは通るようにはなったものの、意図したものが出力されているかはわからないので確認してもらえるとありがたいです。


下にこの変更を適用する前の状態で`npm run pdf`した時の出力を残しておきます。
```Shell
...

Running "shell:compile2pdf" (shell) task
review-pdfmaker  config.yml
ℹ INFO    compiling preface.tex    
ℹ INFO    compiling article.tex    
ℹ INFO    compiling contributors.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
⨯ ERROR   failed to run command: uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex

Error log:

...

(/usr/share/texlive/texmf-dist/tex/generic/pgf/frontendlayer/tikz/libraries/tik
zlibraryfadings.code.tex
(/usr/share/texlive/texmf-dist/tex/generic/pgf/libraries/pgflibraryfadings.code
.tex))) (/usr/share/texlive/texmf-dist/tex/latex/tcolorbox/tcbposter.code.tex
Library (tcolorbox): 'tcbposter.code.tex' version '5.1.1'
)) (/usr/share/texlive/texmf-dist/tex/latex/fancyvrb/fancyvrb.sty)
./techbooster-doujin-base.sty:57: Undefined control sequence.
<argument> \captionwidth 
                         
l.57 ...tolength{\captionwidth}{-\captionnumwidth}
                                                  
               
No pages of output.
Transcript written on _REVIEW_BOOK_.log.
rake aborted!
Command failed with status (1): [review-pdfmaker  config.yml...]
lib/tasks/review.rake:112:in `block in <top (required)>'
/var/lib/gems/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => pdf => ReVIEW-Template.pdf
(See full trace by running task with --trace)
 Use --force to continue.

Aborted due to warnings.
```