### PR TITLE
Enabled contentdir option in config.yml at Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,8 @@ const reviewTextMaker = `${reviewPrefix}rake text ${reviewPostfix}`;
 const reviewIDGXMLMaker = `${reviewPrefix}rake idgxml ${reviewPostfix}`;
 const reviewVivliostyle = `${reviewPrefix}rake vivliostyle ${reviewPostfix}`;
 
+const reviewContentDir = bookConfig.contentdir || '.'
+
 module.exports = grunt => {
 	grunt.initConfig({
 		clean: {
@@ -40,7 +42,7 @@ module.exports = grunt => {
 						cwd: articles,
 					}
 				},
-				command: `${reviewPreproc} -r --tabwidth=2 *.re`
+				command: `${reviewPreproc} -r --tabwidth=2 ${reviewContentDir}/*.re`
 			},
 			compile2text: {
 				options: {


### PR DESCRIPTION
`config.yml` の `contentdir` オプションが `Gruntfile.js` の `preprocess` に渡っていないようだったので修正してみました。
手元で指定したものと無指定それぞれで `build-in-docker.sh` でビルドできることは確認できたので、
他の使い方で問題が出ないようでしたら取り込んでいただくと少し便利になる気がします。

Re:VIEW 初挑戦ですので識者のレビューお待ちしております 🙏 