### PR TITLE
pandoc2review利用時のエラー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ articles/*.html
 # articles/*.md
 articles/*.xml
 articles/*.txt
+articles/_refiles/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = grunt => {
 						cwd: articles,
 					}
 				},
-				command: `${reviewPreproc} -r --tabwidth=2 ${reviewContentDir}/*.re`
+				command: `${reviewContentDir === '_refiles' ? "echo 'skip preprocess'" : `${reviewPreproc} -r --tabwidth=2 ${reviewContentDir}/*.re`}`
 			},
 			compile2text: {
 				options: {

--- a/articles/lib/tasks/z01_pandoc2review.rake
+++ b/articles/lib/tasks/z01_pandoc2review.rake
@@ -28,6 +28,7 @@ def make_mdre(ch, p2r, path)
   elsif File.exist?(ch.sub(/\.re\Z/, '.md')) # md file
     system("#{p2r} #{ch.sub(/\.re\Z/, '.md')} > #{path}/#{ch}")
   end
+  sh "review-preproc -r --tabwidth=2 #{File.join(path, ch)}"
 end
 
 def yaml_load_file_compatible(file)


### PR DESCRIPTION
再現方法:
`articles/config.yml`のcontent_dirを_refilesにする(Line 187をアンコメントする）

pandoc2review利用の設定でcontentdirを_refilesにすると
preprocessでreファイルが存在しないためエラーが発生しました。

エラー文はdescriptionの一番最後に貼り付けています。

そのためpreprocessではなにもせず、
pandoc2review処理時にpreprocessと同様の処理をするように修正しました。

また、pandoc2reviewで生成される`articles/_refiles`ディレクトリはビルドのためのファイルなのでgit対象外にしました。

以下長いですがエラー文です。

```
❯ ./build-in-docker.sh
+ bundle install
Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...
Fetching logger 1.7.0
Fetching mime-types-data 3.2025.0514
Fetching rexml 3.4.1
Fetching rouge 4.5.2
Fetching concurrent-ruby 1.3.5
Fetching rubyzip 2.4.1
Installing logger 1.7.0
Installing mime-types-data 3.2025.0514
Fetching mime-types 3.7.0
Installing rexml 3.4.1
Installing rouge 4.5.2
Installing rubyzip 2.4.1
Installing mime-types 3.7.0
Installing concurrent-ruby 1.3.5
Fetching playwright-ruby-client 1.52.0
Installing playwright-ruby-client 1.52.0
Bundle complete! 4 Gemfile dependencies, 18 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Post-install message from rubyzip:
RubyZip 3.0 is coming!
**********************

The public API of some Rubyzip classes has been modernized to use named
parameters for optional arguments. Please check your usage of the
following classes:
  * `Zip::File`
  * `Zip::Entry`
  * `Zip::InputStream`
  * `Zip::OutputStream`
  * `Zip::DOSTime`

Run your test suite with the `RUBYZIP_V3_API_WARN` environment
variable set to see warnings about usage of the old API. This will
help you to identify any changes that you need to make to your code.
See https://github.com/rubyzip/rubyzip/wiki/Updating-to-version-3.x for
more information.

Please ensure that your Gemfiles and .gemspecs are suitably restrictive
to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
See https://github.com/rubyzip/rubyzip for details. The Changelog also
lists other enhancements and bugfixes that have been implemented since
version 2.3.0.
+ rm -rf node_modules
+ npm install --unsafe-perm
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'review-template@0.0.2',
npm WARN EBADENGINE   required: { node: '>=20.0.0', npm: '>=10.8.0' },
npm WARN EBADENGINE   current: { node: 'v20.13.1', npm: '10.5.2' }
npm WARN EBADENGINE }
npm WARN deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm WARN deprecated osenv@0.1.5: This package is no longer supported.
npm WARN deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm WARN deprecated glob@7.1.7: Glob versions prior to v9 are no longer supported

added 125 packages, and audited 126 packages in 2s

9 packages are looking for funding
  run `npm fund` for details

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
npm notice
npm notice New major version of npm available! 10.5.2 -> 11.3.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.3.0
npm notice Run npm install -g npm@11.3.0 to update!
npm notice

> review-template@0.0.2 pdf
> grunt pdf

Running "clean:review" (clean) task
>> 1 path cleaned.

Running "shell:preprocess" (shell) task
bundler: failed to load command: review-preproc (/usr/local/bin/review-preproc)
/var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `initialize': No such file or directory @ rb_sysopen - _refiles/*.re (Errno::ENOENT)
        from /var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `open'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `process'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:80:in `block in main'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:75:in `each'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:75:in `main'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:32:in `sigmain'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:102:in `<top (required)>'
        from /usr/local/bin/review-preproc:25:in `load'
        from /usr/local/bin/review-preproc:25:in `<top (required)>'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `load'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:23:in `run'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:455:in `exec'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:35:in `dispatch'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:29:in `start'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/exe/bundle:28:in `block in <top (required)>'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/exe/bundle:20:in `<top (required)>'
        from /usr/local/bin/bundle:25:in `load'
        from /usr/local/bin/bundle:25:in `<main>'
Warning: Command failed: bundle exec review-preproc -r --tabwidth=2 _refiles/*.re
bundler: failed to load command: review-preproc (/usr/local/bin/review-preproc)
/var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `initialize': No such file or directory @ rb_sysopen - _refiles/*.re (Errno::ENOENT)
        from /var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `open'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/lib/review/preprocessor.rb:34:in `process'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:80:in `block in main'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:75:in `each'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:75:in `main'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:32:in `sigmain'
        from /var/lib/gems/3.1.0/gems/review-5.8.0/bin/review-preproc:102:in `<top (required)>'
        from /usr/local/bin/review-preproc:25:in `load'
        from /usr/local/bin/review-preproc:25:in `<top (required)>'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `load'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli/exec.rb:23:in `run'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:455:in `exec'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:35:in `dispatch'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/cli.rb:29:in `start'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/exe/bundle:28:in `block in <top (required)>'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /var/lib/gems/3.1.0/gems/bundler-2.5.10/exe/bundle:20:in `<top (required)>'
        from /usr/local/bin/bundle:25:in `load'
        from /usr/local/bin/bundle:25:in `<main>'
 Use --force to continue.

Aborted due to warnings.
```