### PR TITLE
build-in-docker.shで毎回setup.sh実行で時間がかかるのでdocker composeを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM vvakame/review:5.8
+
+WORKDIR /book
+
+COPY . /book
+
+RUN ./setup.sh

--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ Docker環境でも以下のように指定できます。
 $ REVIEW_CONFIG_FILE=config-ebook.yml ./build-in-docker.sh
 ```
 
+Docker Composeを利用すると以下のように指定できます。
+
+```
+$ docker compose up
+```
+または
+
+```
+$ docker compose run -e REVIEW_CONFIG_FILE=config.yml --rm review npm run pdf
+```
+
 紙版と電子版では以下のような違いがあります。
 
  * 紙版：印刷用に、トンボ、デジタルトンボを設置。いくつかの同人誌印刷所で要求事項となっているノドへの隠しノンブル、大扉からのアラビア数字通し。ハイパーリンクは無効化。表紙（cover）は無視。

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+services:
+  review:
+    build:
+      context: .
+    volumes:
+      - .:/book
+    environment:
+      - REVIEW_CONFIG_FILE=config.yml
+    command: npm run pdf


### PR DESCRIPTION
テンプレート作成ありがとうございます。
技術書執筆で活用させていただいております。

いつもdockerを使ってbuildをしています。
build-in-docker.shですと、
setup.shでbundle installとnpm installが毎回されて時間がかかってしまいます。
buildのエラー特定のため、頻繁にbuildを回したいのでsetup.shを毎回実行しなくても済むように
docker composeを追加しました。
(現状ですとDocker Desktopにdocker composeも含まれるようになったので、使い勝手は落ちないと思っています。)

